### PR TITLE
Differentiate backends base classes from engines base classes

### DIFF
--- a/dosna/__init__.py
+++ b/dosna/__init__.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 import logging
 
 from dosna.backends import get_backend, use_backend
-from dosna.base import Backend, Engine
 from dosna.engines import get_engine, use_engine
 
 log = logging.getLogger(__name__)

--- a/dosna/backends/__init__.py
+++ b/dosna/backends/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Helper functions to store and get the selected backend"""
 
+from collections import namedtuple
 import logging
 
 from dosna.utils import named_module
@@ -9,6 +10,9 @@ log = logging.getLogger(__name__)
 
 _current = None
 AVAILABLE = ['ram', 'hdf5', 'ceph']
+
+# Currently there is no need for more fancy attributes
+Backend = namedtuple('Backend', ['name', 'Connection', 'Dataset', 'DataChunk'])
 
 
 def use_backend(backend):

--- a/dosna/backends/ceph.py
+++ b/dosna/backends/ceph.py
@@ -6,8 +6,9 @@ import logging
 import numpy as np
 
 import rados
-from dosna import Backend
-from dosna.base import BaseConnection, BaseDataChunk, BaseDataset
+from dosna.backends import Backend
+from dosna.backends.base import (BackendConnection, BackendDataChunk,
+                                 BackendDataset)
 from dosna.utils import dtype2str, shape2str, str2shape
 
 _SIGNATURE = "DosNa Dataset"
@@ -15,7 +16,7 @@ _SIGNATURE = "DosNa Dataset"
 log = logging.getLogger(__name__)
 
 
-class CephConnection(BaseConnection):
+class CephConnection(BackendConnection):
     """
     A Ceph Cluster that wraps LibRados.Cluster
     """
@@ -104,13 +105,12 @@ class CephConnection(BaseConnection):
 
     def del_dataset(self, name):
         if self.has_dataset(name):
-            self.get_dataset(name).clear()
             self.ioctx.remove_object(name)
         else:
             raise Exception('Dataset `{}` does not exist'.format(name))
 
 
-class CephDataset(BaseDataset):
+class CephDataset(BackendDataset):
     """
     CephDataset wraps an instance of Rados.Object
     """
@@ -156,12 +156,8 @@ class CephDataset(BaseDataset):
         if self.has_chunk(idx):
             self.ioctx.remove_object(self._idx2name(idx))
 
-    def clear(self):
-        for idx in self._ndindex(self.chunks):
-            self.del_chunk(idx)
 
-
-class CephDataChunk(BaseDataChunk):
+class CephDataChunk(BackendDataChunk):
 
     @property
     def ioctx(self):
@@ -191,5 +187,4 @@ class CephDataChunk(BaseDataChunk):
         return self.ioctx.read(self.name, length=length, offset=offset)
 
 
-_backend = Backend('ceph', CephConnection, CephDataset,
-                      CephDataChunk)
+_backend = Backend('ceph', CephConnection, CephDataset, CephDataChunk)

--- a/dosna/backends/hdf5.py
+++ b/dosna/backends/hdf5.py
@@ -8,8 +8,9 @@ import shutil
 import h5py as h5
 import numpy as np
 
-from dosna import Backend
-from dosna.base import BaseConnection, BaseDataChunk, BaseDataset
+from dosna.backends import Backend
+from dosna.backends.base import (BackendConnection, BackendDataChunk,
+                                 BackendDataset)
 from dosna.utils import DirectoryTreeMixin, dtype2str
 
 _DATASET_METADATA_FILENAME = 'dataset.h5'
@@ -21,7 +22,7 @@ def _validate_path(path):
         raise Exception('`{}` is not a valid path'.format(path))
 
 
-class H5Connection(BaseConnection, DirectoryTreeMixin):
+class H5Connection(BackendConnection, DirectoryTreeMixin):
     """
     A HDF5 Cluster represents the local filesystem.
     """
@@ -107,7 +108,7 @@ class H5Connection(BaseConnection, DirectoryTreeMixin):
         shutil.rmtree(path)
 
 
-class H5Dataset(BaseDataset, DirectoryTreeMixin):
+class H5Dataset(BackendDataset, DirectoryTreeMixin):
 
     def __init__(self, *args, **kwargs):
         super(H5Dataset, self).__init__(*args, **kwargs)
@@ -155,7 +156,7 @@ class H5Dataset(BaseDataset, DirectoryTreeMixin):
             os.remove(self.relpath(self._idx2name(idx)))
 
 
-class H5DataChunk(BaseDataChunk, DirectoryTreeMixin):
+class H5DataChunk(BackendDataChunk, DirectoryTreeMixin):
 
     def __init__(self, *args, **kwargs):
         super(H5DataChunk, self).__init__(*args, **kwargs)

--- a/dosna/backends/ram.py
+++ b/dosna/backends/ram.py
@@ -5,13 +5,14 @@ import logging
 
 import numpy as np
 
-from dosna import Backend
-from dosna.base import BaseConnection, BaseDataChunk, BaseDataset
+from dosna.backends import Backend
+from dosna.backends.base import (BackendConnection, BackendDataChunk,
+                                 BackendDataset)
 
 log = logging.getLogger(__name__)
 
 
-class MemConnection(BaseConnection):
+class MemConnection(BackendConnection):
     """
     A Memory Connection represents a dictionary.
     """
@@ -60,7 +61,7 @@ class MemConnection(BaseConnection):
         del self.datasets[name]
 
 
-class MemDataset(BaseDataset):
+class MemDataset(BackendDataset):
 
     def __init__(self, pool, name, shape, dtype, fillvalue, chunks, csize):
         super(MemDataset, self).__init__(pool, name, shape, dtype, fillvalue,
@@ -100,7 +101,7 @@ class MemDataset(BaseDataset):
             del self.data_chunks[idx]
 
 
-class MemDataChunk(BaseDataChunk):
+class MemDataChunk(BackendDataChunk):
 
     def __init__(self, dataset, idx, name, shape, dtype, fillvalue):
         super(MemDataChunk, self).__init__(dataset, idx, name, shape,

--- a/dosna/engines/__init__.py
+++ b/dosna/engines/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Helper functions to store and get the selected engine"""
 
+from collections import namedtuple
 import logging as log
 
 from dosna.utils import named_module
@@ -8,6 +9,9 @@ from dosna.utils import named_module
 AVAILABLE = ['cpu', 'jl', 'mpi']
 
 _current = None
+
+Engine = namedtuple('Engine', ['name', 'Connection', 'Dataset', 'DataChunk',
+                               'params'])
 
 
 def use_engine(engine, **kwargs):

--- a/dosna/engines/base.py
+++ b/dosna/engines/base.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+"""Base classes for every engine"""
+
+
+import logging
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+
+class BackendWrapper(object):
+
+    instance = None
+
+    def __init__(self, instance):
+        self.instance = instance
+
+    def __getattr__(self, attr):
+        """
+        Attributes/Functions that do not exist in the extended class
+        are going to be passed to the instance being wrapped
+        """
+        return self.instance.__getattribute__(attr)
+
+    def __enter__(self):
+        self.instance.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        self.instance.__exit__(*args)
+
+
+class EngineConnection(BackendWrapper):
+
+    def create_dataset(self, name, shape=None, dtype=np.float32, fillvalue=0,
+                       data=None, chunks=None):
+        self.instance.create_dataset(name, shape, dtype, fillvalue,
+                                     data, chunks)
+        dataset = self.get_dataset(name)
+        if data is not None:
+            dataset.load(data)
+        return dataset
+
+    def get_dataset(self, name):
+        # this is meant to wrap the dataset with the specific engine class
+        raise NotImplementedError('`get_dataset` not implemented '
+                                  'for this engine')
+
+    def del_dataset(self, name):
+        dataset = self.get_dataset(name)
+        dataset.clear()
+        self.instance.del_dataset(name)
+
+    def __getitem__(self, dataset_name):
+        return self.get_dataset(dataset_name)
+
+
+class EngineDataset(BackendWrapper):
+
+    def get_data(self, slices=None):
+        raise NotImplementedError('`get_data` not implemented for this engine')
+
+    def set_data(self, values, slices=None):
+        raise NotImplementedError('`set_data` not implemented for this engine')
+
+    def clear(self):
+        raise NotImplementedError('`clear` not implemented for this engine')
+
+    def delete(self):
+        self.clear()
+        self.instance.connection.del_dataset(self.name)
+
+    def load(self, data):
+        raise NotImplementedError('`load` not implemented for this engine')
+
+    def map(self, func, output_name):
+        raise NotImplementedError('`map` not implemented for this engine')
+
+    def apply(self, func):
+        raise NotImplementedError('`apply` not implemented for this engine')
+
+    def clone(self, output_name):
+        raise NotImplementedError('`clone` not implemented for this engine')
+
+    def create_chunk(self, idx, data=None, slices=None):
+        self.instance.create_chunk(idx, data, slices)
+        return self.get_chunk(idx)
+
+    def get_chunk(self, idx):
+        raise NotImplementedError('`create_chunk` not implemented '
+                                  'for this backend')
+
+    def del_chunk(self, idx):
+        # just for base completeness
+        self.instance.del_chunk(idx)
+
+    def __getitem__(self, slices):
+        return self.get_data(slices)
+
+    def __setitem__(self, slices, values):
+        self.set_data(values, slices=slices)
+
+
+class EngineDataChunk(BackendWrapper):
+    pass

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ "$#" -eq 0 ]; then
     echo "Unittest discovery mode"
     echo "========================================"
-    PYTHONPATH=. python -m unittest discover -s dosna/tests -v
+    PYTHONPATH=. python -m unittest discover -s "${SDIR}/dosna/tests" -v
 else
     echo "Unittest manual mode:" $@
     for script in 'connection' 'dataset';
@@ -11,7 +12,7 @@ else
         echo "========================================"
         echo "Running tests on ${script}"
         echo "========================================"
-        PYTHONPATH=".:$PYTHONPATH"
-        python dosna/tests/test_${script}.py $@
+        PYTHONPATH="${SDIR}:$PYTHONPATH"
+        python "${SDIR}/dosna/tests/test_${script}.py" $@
     done
 fi


### PR DESCRIPTION
- Split base classes in two separate files
- Simplify engines and backends implementations