### PR TITLE
Saves sliced image with appropriate filename identifier 

### DIFF
--- a/dosna/webapp/webapp.py
+++ b/dosna/webapp/webapp.py
@@ -102,8 +102,9 @@ def display_image_object(pool, obj):
         object_data = cluster.get_dataset(str(obj))
         img = Image.fromarray(object_data[:, :, 0], 'RGB')
         cluster.disconnect()
-        fileLocation = 'static/' + str(obj) + '.jpeg'
-        filename = obj + '.jpeg'
+        fileFolder = 'static/'
+        filename = str(obj) + '.jpeg'
+        fileLocation = fileFolder + filename
         img.save(fileLocation)
         return render_template('objectImage.html', filename=filename, obj=obj)
     except (rados.Error,
@@ -121,6 +122,7 @@ def display_image_object(pool, obj):
 def display_image_object_slice(pool, obj, xslice, yslice, zslice):
     """ Display object as an image with slice specified """
     dn.use_backend(BACKEND)
+    slices = [xslice, yslice,zslice]
     xslice = re.split(":", xslice)
     xslice = [int(i) for i in xslice]
     yslice = re.split(":", yslice)
@@ -137,8 +139,13 @@ def display_image_object_slice(pool, obj, xslice, yslice, zslice):
                             zslice[0]:zslice[1]],
                             'RGB')
         cluster.disconnect()
-        fileLocation = 'static/' + str(obj) + '.jpeg'
-        filename = obj + '.jpeg'
+        fileFolder = 'static/'
+        filename = (str(obj) + "#"
+                    + str(xslice[0]) + ":" + str(xslice[1]) + "#"
+                    + str(yslice[0]) + ":" + str(yslice[1]) + "#"
+                    + str(zslice[0]) + ":" + str(zslice[1])
+                    + '.jpeg')
+        fileLocation = fileFolder + filename
         img.save(fileLocation)
         return render_template('objectImage.html', filename=filename, obj=obj)
     except (rados.Error,

--- a/dosna/webapp/webapp.py
+++ b/dosna/webapp/webapp.py
@@ -122,7 +122,6 @@ def display_image_object(pool, obj):
 def display_image_object_slice(pool, obj, xslice, yslice, zslice):
     """ Display object as an image with slice specified """
     dn.use_backend(BACKEND)
-    slices = [xslice, yslice, zslice]
     xslice = re.split(":", xslice)
     xslice = [int(i) for i in xslice]
     yslice = re.split(":", yslice)

--- a/dosna/webapp/webapp.py
+++ b/dosna/webapp/webapp.py
@@ -122,7 +122,7 @@ def display_image_object(pool, obj):
 def display_image_object_slice(pool, obj, xslice, yslice, zslice):
     """ Display object as an image with slice specified """
     dn.use_backend(BACKEND)
-    slices = [xslice, yslice,zslice]
+    slices = [xslice, yslice, zslice]
     xslice = re.split(":", xslice)
     xslice = [int(i) for i in xslice]
     yslice = re.split(":", yslice)


### PR DESCRIPTION
During the demonstration, I realised that the sliced images overwrite the non-sliced ones. This now ensures that the images are saved under different names.